### PR TITLE
Update crud.js

### DIFF
--- a/modules/crud.js
+++ b/modules/crud.js
@@ -5,6 +5,7 @@
   r.connect( {host: 'localhost', port: 28015}, function(err, conn) {
     if (err) throw err;
     connection = conn;
+    conn.use('api')
     r.db('api').tableCreate('cruds').run(conn, function(err, res) {
       if (err){
         if(err.name === "RqlRuntimeError") {


### PR DESCRIPTION
Fix database name issue. r.table('crud') could have went to another database. It could be r.db('api').table('crud') but fixed one line code.